### PR TITLE
issue #3 Add vim motions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,27 @@ Modern DAG/tasks runner.
 ```
 cargo install --git https://github.com/zifeo/whiz --locked
 ```
+
+## Key bindings
+
+### navigation
+
+| Keys         | Motion                              |
+| ------------ | ----------------------------------- |
+| l, RighArrow | go to next tab                      |
+| h, LeftArrow | go to previous tab                  |
+| k, Ctl + p   | scroll up one line                  |
+| j, Ctl + n   | scroll down one line                |
+| Ctl + u      | scroll up half page                 |
+| Ctl + d      | scroll down half page               |
+| Ctl + b      | scroll up full page                 |
+| Ctl + f      | scroll down full page               |
+| 0            | go to last tab                      |
+| 1-9          | go to the tab at the given position |
+
+### actions
+
+| Keys       | Motion                            |
+| ---------- | --------------------------------- |
+| q, Ctl + c | exit the program                  |
+| r          | rerun the task in the current tab |

--- a/src/actors/console.rs
+++ b/src/actors/console.rs
@@ -230,16 +230,18 @@ impl Handler<TermEvent> for ConsoleActor {
                         focus.command.do_send(Reload::Manual);
                     }
                 }
-                (_, KeyCode::Right) => {
+                (_, KeyCode::Right | KeyCode::Char('l')) => {
                     self.next();
                 }
-                (_, KeyCode::Left) => {
+                (_, KeyCode::Left | KeyCode::Char('h')) => {
                     self.previous();
                 }
-                (_, KeyCode::Up) => {
+                (_, KeyCode::Up | KeyCode::Char('k'))
+                | (KeyModifiers::CONTROL, KeyCode::Char('p')) => {
                     self.up();
                 }
-                (_, KeyCode::Down) => {
+                (_, KeyCode::Down | KeyCode::Char('j'))
+                | (KeyModifiers::CONTROL, KeyCode::Char('n')) => {
                     self.down();
                 }
                 _ => {}

--- a/src/actors/console.rs
+++ b/src/actors/console.rs
@@ -101,6 +101,12 @@ impl ConsoleActor {
         chunks(&frame)[0].height
     }
 
+    pub fn go_to(&mut self, panel_index: usize) {
+        if panel_index < self.order.len() {
+            self.index = self.order[panel_index].clone();
+        }
+    }
+
     pub fn idx(&self) -> usize {
         self.order
             .iter()
@@ -272,6 +278,19 @@ impl Handler<TermEvent> for ConsoleActor {
                 (KeyModifiers::CONTROL, KeyCode::Char('f')) => {
                     let log_height = self.get_log_height();
                     self.down(log_height);
+                }
+                (KeyModifiers::NONE, KeyCode::Char(ch)) => {
+                    if ch.is_ascii_digit() {
+                        let mut panel_index = ch.to_digit(10).unwrap() as usize;
+                        // first tab is key 1, therefore
+                        // in key 0 go to last tab
+                        if panel_index == 0 {
+                            panel_index = self.order.len() - 1;
+                        } else {
+                            panel_index -= 1;
+                        }
+                        self.go_to(panel_index);
+                    }
                 }
                 _ => {}
             },

--- a/src/actors/console.rs
+++ b/src/actors/console.rs
@@ -17,7 +17,7 @@ use tui::{
 };
 
 use crossterm::{
-    cursor::{self},
+    cursor,
     event::{self, Event, KeyCode, KeyModifiers, MouseEventKind},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},

--- a/src/actors/console.rs
+++ b/src/actors/console.rs
@@ -245,17 +245,6 @@ impl Handler<TermEvent> for ConsoleActor {
                         .for_each(|e| e.command.do_send(PoisonPill));
                     System::current().stop();
                 }
-                (KeyModifiers::NONE, KeyCode::Char('r')) => {
-                    if let Some(focused_panel) = self.panels.get(&self.index) {
-                        focused_panel.command.do_send(Reload::Manual);
-                    }
-                }
-                (KeyModifiers::NONE, KeyCode::Right | KeyCode::Char('l')) => {
-                    self.next();
-                }
-                (KeyModifiers::NONE, KeyCode::Left | KeyCode::Char('h')) => {
-                    self.previous();
-                }
                 (KeyModifiers::NONE, KeyCode::Up | KeyCode::Char('k'))
                 | (KeyModifiers::CONTROL, KeyCode::Char('p')) => {
                     self.up(1);
@@ -264,35 +253,52 @@ impl Handler<TermEvent> for ConsoleActor {
                 | (KeyModifiers::CONTROL, KeyCode::Char('n')) => {
                     self.down(1);
                 }
-                (KeyModifiers::CONTROL, KeyCode::Char('u')) => {
-                    let log_height = self.get_log_height();
-                    self.up(log_height / 2);
-                }
-                (KeyModifiers::CONTROL, KeyCode::Char('d')) => {
-                    let log_height = self.get_log_height();
-                    self.down(log_height / 2);
-                }
-                (KeyModifiers::CONTROL, KeyCode::Char('b')) => {
-                    let log_height = self.get_log_height();
-                    self.up(log_height);
-                }
-                (KeyModifiers::CONTROL, KeyCode::Char('f')) => {
-                    let log_height = self.get_log_height();
-                    self.down(log_height);
-                }
-                (KeyModifiers::NONE, KeyCode::Char(ch)) => {
-                    if ch.is_ascii_digit() {
-                        let mut panel_index = ch.to_digit(10).unwrap() as usize;
-                        // first tab is key 1, therefore
-                        // in key 0 go to last tab
-                        if panel_index == 0 {
-                            panel_index = self.order.len() - 1;
-                        } else {
-                            panel_index -= 1;
-                        }
-                        self.go_to(panel_index);
+                (KeyModifiers::CONTROL, key_code) => match key_code {
+                    KeyCode::Char('f') => {
+                        let log_height = self.get_log_height();
+                        self.down(log_height);
                     }
-                }
+                    KeyCode::Char('u') => {
+                        let log_height = self.get_log_height();
+                        self.up(log_height / 2);
+                    }
+                    KeyCode::Char('d') => {
+                        let log_height = self.get_log_height();
+                        self.down(log_height / 2);
+                    }
+                    KeyCode::Char('b') => {
+                        let log_height = self.get_log_height();
+                        self.up(log_height);
+                    }
+                    _ => {}
+                },
+                (KeyModifiers::NONE, key_code) => match key_code {
+                    KeyCode::Char('r') => {
+                        if let Some(focused_panel) = self.panels.get(&self.index) {
+                            focused_panel.command.do_send(Reload::Manual);
+                        }
+                    }
+                    KeyCode::Right | KeyCode::Char('l') => {
+                        self.next();
+                    }
+                    KeyCode::Left | KeyCode::Char('h') => {
+                        self.previous();
+                    }
+                    KeyCode::Char(ch) => {
+                        if ch.is_ascii_digit() {
+                            let mut panel_index = ch.to_digit(10).unwrap() as usize;
+                            // first tab is key 1, therefore
+                            // in key 0 go to last tab
+                            if panel_index == 0 {
+                                panel_index = self.order.len() - 1;
+                            } else {
+                                panel_index -= 1;
+                            }
+                            self.go_to(panel_index);
+                        }
+                    }
+                    _ => {}
+                },
                 _ => {}
             },
             Event::Resize(width, _) => {

--- a/src/actors/console.rs
+++ b/src/actors/console.rs
@@ -238,28 +238,29 @@ impl Handler<TermEvent> for ConsoleActor {
     fn handle(&mut self, msg: TermEvent, _: &mut Context<Self>) -> Self::Result {
         match msg.0 {
             Event::Key(e) => match (e.modifiers, e.code) {
-                (KeyModifiers::CONTROL, KeyCode::Char('c')) | (_, KeyCode::Char('q')) => {
+                (KeyModifiers::CONTROL, KeyCode::Char('c'))
+                | (KeyModifiers::NONE, KeyCode::Char('q')) => {
                     self.panels
                         .values()
                         .for_each(|e| e.command.do_send(PoisonPill));
                     System::current().stop();
                 }
-                (_, KeyCode::Char('r')) => {
+                (KeyModifiers::NONE, KeyCode::Char('r')) => {
                     if let Some(focused_panel) = self.panels.get(&self.index) {
                         focused_panel.command.do_send(Reload::Manual);
                     }
                 }
-                (_, KeyCode::Right | KeyCode::Char('l')) => {
+                (KeyModifiers::NONE, KeyCode::Right | KeyCode::Char('l')) => {
                     self.next();
                 }
-                (_, KeyCode::Left | KeyCode::Char('h')) => {
+                (KeyModifiers::NONE, KeyCode::Left | KeyCode::Char('h')) => {
                     self.previous();
                 }
-                (_, KeyCode::Up | KeyCode::Char('k'))
+                (KeyModifiers::NONE, KeyCode::Up | KeyCode::Char('k'))
                 | (KeyModifiers::CONTROL, KeyCode::Char('p')) => {
                     self.up(1);
                 }
-                (_, KeyCode::Down | KeyCode::Char('j'))
+                (KeyModifiers::NONE, KeyCode::Down | KeyCode::Char('j'))
                 | (KeyModifiers::CONTROL, KeyCode::Char('n')) => {
                     self.down(1);
                 }


### PR DESCRIPTION
Fixes issue #3

I have added the following vim motions:

- l: next tab
- h: previous tab
- j/\<C-n\>: scroll down
- k/\<C-p\>: scroll up
- \<C-u\>: scroll up half page
- \<C-d\>: scroll down half page
- \<C-b\>: scroll up full page
- \<C-f\>: scroll down full page
- /\d/: jump to the specified tab
