### PR TITLE
Add option to run specific jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,33 @@
 # Whiz
 
-Modern DAG/tasks runner.
+Modern [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph)/tasks runner.
 
 ## Getting started
 
 ```
 cargo install --git https://github.com/zifeo/whiz --locked
 ```
+
+## Usage
+
+### passing list of values
+
+You can pass list of values for an option by repeating their flag
+
+```sh
+whiz --arg arg1 --arg arg2
+```
+
+## Flags
+
+| Flags             | Description                  |
+| ----------------- | ---------------------------- |
+| -f, --file        | specify the config file      |
+| -h, --help        | print help information       |
+| -r, --run \<JOB\> | run specific jobs            |
+| -t, --timestamp   | enable timestamps in logging |
+| -v, --verbose     | enable verbose mode          |
+| -V, --version     | print whiz version           |
 
 ## Key bindings
 
@@ -27,7 +48,7 @@ cargo install --git https://github.com/zifeo/whiz --locked
 
 ### actions
 
-| Keys       | Motion                            |
-| ---------- | --------------------------------- |
-| q, Ctl + c | exit the program                  |
-| r          | rerun the task in the current tab |
+| Keys       | Motion                           |
+| ---------- | -------------------------------- |
+| q, Ctl + c | exit the program                 |
+| r          | rerun the job in the current tab |

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,14 +95,15 @@ impl Config {
     pub fn filter_jobs(&mut self, run: &Vec<String>) -> Result<()> {
         for job_name in run {
             if self.ops.get(job_name).is_none() {
-                let formatted_list_of_jobs = self
+                let mut formatted_list_of_jobs = self
                     .ops
                     .iter()
                     .map(|(job_name, _)| format!("  - {job_name}"))
-                    .collect::<Vec<String>>()
-                    .join("\n");
+                    .collect::<Vec<String>>();
+                formatted_list_of_jobs.sort();
+                let formatted_list_of_jobs = formatted_list_of_jobs.join("\n");
                 let error_header = format!("job '{job_name}' not found in config file.");
-                let error_sugesstion = format!("Valid jobs are: \n{formatted_list_of_jobs}");
+                let error_sugesstion = format!("Valid jobs are:\n{formatted_list_of_jobs}");
                 let error_message = format!("{error_header}\n\n{error_sugesstion}");
                 bail!(error_message);
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,8 +103,8 @@ impl Config {
                 formatted_list_of_jobs.sort();
                 let formatted_list_of_jobs = formatted_list_of_jobs.join("\n");
                 let error_header = format!("job '{job_name}' not found in config file.");
-                let error_sugesstion = format!("Valid jobs are:\n{formatted_list_of_jobs}");
-                let error_message = format!("{error_header}\n\n{error_sugesstion}");
+                let error_suggestion = format!("Valid jobs are:\n{formatted_list_of_jobs}");
+                let error_message = format!("{error_header}\n\n{error_suggestion}");
                 bail!(error_message);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,13 +14,13 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    #[clap(short, long, value_parser, default_value = "whiz.yaml")]
+    #[clap(short, long, default_value = "whiz.yaml")]
     file: String,
 
-    #[clap(short, long, value_parser)]
+    #[clap(short, long)]
     verbose: bool,
 
-    #[clap(short, long, value_parser)]
+    #[clap(short, long)]
     timestamp: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,12 +22,16 @@ struct Args {
 
     #[clap(short, long)]
     timestamp: bool,
+
+    /// Run specific jobs
+    #[clap(short, long, value_name = "JOB")]
+    run: Vec<String>,
 }
 
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    let config = match Config::from_file(&args.file) {
+    let mut config = match Config::from_file(&args.file) {
         Ok(conf) => conf,
         Err(err) => {
             println!("file error: {}", err);
@@ -35,9 +39,14 @@ fn main() -> Result<()> {
         }
     };
 
+    if let Err(err) = config.filter_jobs(&args.run) {
+        println!("argument error: {}", err);
+        process::exit(2);
+    };
+
     if let Err(err) = config.build_dag() {
         println!("config error: {}", err);
-        process::exit(2);
+        process::exit(3);
     };
 
     let base_dir = env::current_dir()?


### PR DESCRIPTION
Fixes #2.

Added `run` option which differs from the implementation described in #2 with the flag `only` to run one job, this is to provide more flexibility by allowing to run one or more jobs using the same option.