### PR TITLE
feat: better CI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,23 +84,24 @@ See `whiz --help` for more information.
 | -t, --timestamp     | enable timestamps in logging |
 | -v, --verbose       | enable verbose mode          |
 | -V, --version       | print whiz version           |
+| -V, --version       | print whiz version           |
+| --watch             | globally enable/disable fs watching |
+
 
 ### Key bindings
 
-| Keys         | Action                              |
-| ------------ | ----------------------------------- |
-| l, RighArrow | go to next tab                      |
-| h, LeftArrow | go to previous tab                  |
-| k, Ctl + p   | scroll up one line                  |
-| j, Ctl + n   | scroll down one line                |
-| Ctl + u      | scroll up half page                 |
-| Ctl + d      | scroll down half page               |
-| Ctl + b      | scroll up full page                 |
-| Ctl + f      | scroll down full page               |
-| 0            | go to last tab                      |
-| 1-9          | go to the tab at the given position |
-| q, Ctl + c   | exit the program                    |
-| r            | rerun the job in the current tab    |
+| Flags               | Description                                       |
+| ------------------- | ------------------------------------------------- |
+| -f, --file \<FILE\> | Specify the config file                           |
+| -h, --help          | Print help information                            |
+| --list-jobs         | List all the available jobs                       |
+| -r, --run \<JOB\>   | Run specific jobs                                 |
+| -t, --timestamp     | Enable timestamps in logging                      |
+| -v, --verbose       | Enable verbose mode                               |
+| -V, --version       | Print whiz version                                |
+| -V, --version       | Print whiz version                                |
+| --watch             | Globally enable/disable fs watching               |
+| --exit-after        | Exit whiz after all tasks are done. Useful for CI | 
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -75,21 +75,6 @@ complete example.
 
 See `whiz --help` for more information.
 
-| Flags               | Description                  |
-| ------------------- | ---------------------------- |
-| -f, --file \<FILE\> | specify the config file      |
-| -h, --help          | print help information       |
-| --list-jobs         | list all the available jobs  |
-| -r, --run \<JOB\>   | run specific jobs            |
-| -t, --timestamp     | enable timestamps in logging |
-| -v, --verbose       | enable verbose mode          |
-| -V, --version       | print whiz version           |
-| -V, --version       | print whiz version           |
-| --watch             | globally enable/disable fs watching |
-
-
-### Key bindings
-
 | Flags               | Description                                       |
 | ------------------- | ------------------------------------------------- |
 | -f, --file \<FILE\> | Specify the config file                           |
@@ -102,6 +87,24 @@ See `whiz --help` for more information.
 | -V, --version       | Print whiz version                                |
 | --watch             | Globally enable/disable fs watching               |
 | --exit-after        | Exit whiz after all tasks are done. Useful for CI | 
+
+
+### Key bindings
+
+| Keys         | Action                              |
+| ------------ | ----------------------------------- |
+| l, RighArrow | go to next tab                      |
+| h, LeftArrow | go to previous tab                  |
+| k, Ctl + p   | scroll up one line                  |
+| j, Ctl + n   | scroll down one line                |
+| Ctl + u      | scroll up half page                 |
+| Ctl + d      | scroll down half page               |
+| Ctl + b      | scroll up full page                 |
+| Ctl + f      | scroll down full page               |
+| 0            | go to last tab                      |
+| 1-9          | go to the tab at the given position |
+| q, Ctl + c   | exit the program                    |
+| r            | rerun the job in the current tab    |
 
 ## Development
 

--- a/src/actors/command.rs
+++ b/src/actors/command.rs
@@ -471,9 +471,14 @@ impl CommandActor {
 
     fn accept_death_invite(&mut self, cx: &mut Context<Self>) {
         if let Some(invite) = self.death_invite.take() {
+            let status = match &self.child {
+                Child::Killed => ExitStatus::Other(1),
+                Child::Exited(val) => *val,
+                child => panic!("invalid death invite acceptance: {child:?}"),
+            };
             invite.rsvp::<Self, Context<Self>>(
                 self.op_name.clone(),
-                self.child.exit_status().unwrap(),
+                status,
                 cx,
             );
         }

--- a/src/actors/command.rs
+++ b/src/actors/command.rs
@@ -1,4 +1,4 @@
-use actix::clock::sleep;
+use actix::clock::{sleep, timeout};
 use actix::prelude::*;
 
 use anyhow::{Context as ErrorContext, Result};
@@ -476,11 +476,7 @@ impl CommandActor {
                 Child::Exited(val) => *val,
                 child => panic!("invalid death invite acceptance: {child:?}"),
             };
-            invite.rsvp::<Self, Context<Self>>(
-                self.op_name.clone(),
-                status,
-                cx,
-            );
+            invite.rsvp::<Self, Context<Self>>(self.op_name.clone(), status, cx);
         }
     }
 }
@@ -668,19 +664,44 @@ struct StdoutTerminated {
 }
 
 impl Handler<StdoutTerminated> for CommandActor {
-    type Result = ();
+    type Result = ResponseActFuture<Self, ()>;
 
     fn handle(&mut self, msg: StdoutTerminated, cx: &mut Self::Context) -> Self::Result {
-        if msg.started_at == self.started_at {
-            self.ensure_stopped();
-            let exit = self.child.exit_status();
-
-            self.console.do_send(PanelStatus {
-                panel_name: self.op_name.clone(),
+        // early exit
+        if msg.started_at != self.started_at {
+            return Box::pin(async {}.into_actor(self).map(|_, _, _| ()));
+        }
+        let addr = cx.address();
+        // since there's a chance that child might not be done by this point
+        // wait for it die for a maximum of 1 seconds
+        // polling every 20 millis
+        // before pulling the plug
+        let fut = timeout(Duration::from_secs(1), async move {
+            loop {
+                if let Some(status) = addr.send(GetStatus).await.unwrap().unwrap() {
+                    return status;
+                }
+                sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .into_actor(self)
+        .map(|res, act, cx| {
+            let exit = if let Ok(status) = res {
+                act.send_reload(); // signal any dependents, this boy's goin down
+                Some(status)
+            } else {
+                // timeout and child is not still dead
+                // pull the plug
+                act.ensure_stopped();
+                act.child.exit_status()
+            };
+            act.console.do_send(PanelStatus {
+                panel_name: act.op_name.clone(),
                 status: exit,
             });
-            self.accept_death_invite(cx);
-        }
+            act.accept_death_invite(cx);
+        });
+        Box::pin(fut)
     }
 }
 

--- a/src/actors/command.rs
+++ b/src/actors/command.rs
@@ -21,6 +21,7 @@ use std::{
 use shlex;
 
 use crate::config::color::ColorOption;
+use crate::actors::grim_reaper::PermaDeathInvite;
 use crate::config::{
     pipe::{OutputRedirection, Pipe},
     Config, Task,
@@ -115,6 +116,7 @@ pub struct CommandActor {
     colors: Vec<ColorOption>,
     entrypoint: Option<String>,
     no_watch: bool,
+    death_invite: Option<PermaDeathInvite>,
 }
 
 impl CommandActor {
@@ -127,7 +129,7 @@ impl CommandActor {
         pipes_map: HashMap<String, Vec<Pipe>>,
         colors_map: HashMap<String, Vec<ColorOption>>,
         global_no_watch: bool,
-    ) -> Result<Vec<Addr<CommandActor>>> {
+    ) -> Result<HashMap<String, Addr<CommandActor>>> {
         let mut shared_env = HashMap::from_iter(std::env::vars());
         shared_env.extend(lade_sdk::resolve(&config.env, &shared_env)?);
         let shared_env = lade_sdk::hydrate(shared_env, base_dir.clone()).await?;
@@ -186,7 +188,8 @@ impl CommandActor {
             commands.insert(op_name, actor);
         }
 
-        Ok(commands.values().map(|i| i.to_owned()).collect::<Vec<_>>())
+        // Ok(commands.values().map(|i| i.to_owned()).collect::<Vec<_>>())
+        Ok(commands)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -222,6 +225,7 @@ impl CommandActor {
             colors,
             entrypoint,
             no_watch,
+            death_invite: None,
         }
     }
 
@@ -415,6 +419,12 @@ impl CommandActor {
 
         Ok(())
     }
+
+    fn accept_death_invite(&mut self) {
+        if let Some(invite) = self.death_invite.take() {
+            invite.rsvp(self.op_name.clone(), self.child.exit_status().unwrap());
+        }
+    }
 }
 
 impl Actor for CommandActor {
@@ -517,6 +527,10 @@ impl Handler<Reload> for CommandActor {
     fn handle(&mut self, msg: Reload, _: &mut Context<Self>) -> Self::Result {
         self.ensure_stopped();
 
+        if self.death_invite.is_some() {
+            return;
+        }
+
         match &msg {
             Reload::Start => {
                 self.send_will_reload();
@@ -610,6 +624,7 @@ impl Handler<StdoutTerminated> for CommandActor {
                 panel_name: self.op_name.clone(),
                 status: exit,
             });
+            self.accept_death_invite();
         }
     }
 }
@@ -622,6 +637,20 @@ impl Handler<PoisonPill> for CommandActor {
     type Result = ();
 
     fn handle(&mut self, _: PoisonPill, ctx: &mut Context<Self>) -> Self::Result {
+        self.accept_death_invite();
         ctx.stop();
+    }
+}
+
+impl Handler<PermaDeathInvite> for CommandActor {
+    type Result = ();
+
+    fn handle(&mut self, evt: PermaDeathInvite, _: &mut Context<Self>) -> Self::Result {
+        self.child.poll(false).unwrap();
+        if let Some(status) = self.child.exit_status() {
+            evt.rsvp(self.op_name.clone(), status);
+        } else {
+            self.death_invite = Some(evt);
+        }
     }
 }

--- a/src/actors/grim_reaper.rs
+++ b/src/actors/grim_reaper.rs
@@ -1,0 +1,84 @@
+use std::collections::{HashMap, HashSet};
+
+use actix::prelude::*;
+use subprocess::ExitStatus;
+
+pub struct GrimReaperActor {
+    live_invites: HashSet<String>,
+    non_zero_deaths: HashMap<String, ExitStatus>,
+}
+
+impl GrimReaperActor {
+    pub async fn start_new<T>(targets: HashMap<String, Addr<T>>) -> anyhow::Result<()>
+    where
+        T: Actor + Handler<PermaDeathInvite>,
+        <T as actix::Actor>::Context: actix::dev::ToEnvelope<T, PermaDeathInvite>,
+    {
+        let reaper_addr = GrimReaperActor {
+            live_invites: targets.keys().cloned().collect(),
+            non_zero_deaths: Default::default(),
+        }
+        .start();
+        for target in targets.values() {
+            target
+                .send(PermaDeathInvite {
+                    reaper_addr: reaper_addr.clone(),
+                })
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+impl Actor for GrimReaperActor {
+    type Context = Context<Self>;
+}
+
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct PermaDeathInvite {
+    reaper_addr: Addr<crate::actors::grim_reaper::GrimReaperActor>,
+}
+
+impl PermaDeathInvite {
+    pub fn rsvp(self, actor_name: String, exit_status: ExitStatus) {
+        // FIXME: `do_send` might fail if actor "mailbox" is full
+        self.reaper_addr.do_send(InviteAccepted {
+            actor_name,
+            exit_status,
+        });
+    }
+}
+
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct InviteAccepted {
+    actor_name: String,
+    exit_status: ExitStatus,
+}
+
+impl Handler<InviteAccepted> for GrimReaperActor {
+    type Result = ();
+
+    fn handle(&mut self, evt: InviteAccepted, _: &mut Context<Self>) -> Self::Result {
+        assert!(self.live_invites.remove(&evt.actor_name));
+        if !evt.exit_status.success() {
+            self.non_zero_deaths.insert(evt.actor_name, evt.exit_status);
+        }
+        if self.live_invites.is_empty() {
+            if let Some((_op_name, status)) = self.non_zero_deaths.iter().next() {
+                // exit with the error code of the first aberrant task
+                let code = match *status {
+                    ExitStatus::Exited(code) => code as i32,
+                    ExitStatus::Other(code) => code,
+                    ExitStatus::Signaled(code) => code as i32,
+                    // TODO: consider erring out on Undetermined
+                    ExitStatus::Undetermined => 0,
+                };
+                System::current().stop_with_code(code);
+            }
+            System::current().stop();
+        }
+    }
+}
+

--- a/src/actors/grim_reaper.rs
+++ b/src/actors/grim_reaper.rs
@@ -3,6 +3,9 @@ use std::collections::{HashMap, HashSet};
 use actix::prelude::*;
 use subprocess::ExitStatus;
 
+/// This is responsible for exiting whiz when all tasks are done.
+/// It `send`s it's targets `PermaDeathInvite` which and when all
+/// have been `rsvp`d, terminates the Actix runtime and thus the program.
 pub struct GrimReaperActor {
     live_invites: HashSet<String>,
     non_zero_deaths: HashMap<String, ExitStatus>,
@@ -42,6 +45,8 @@ pub struct PermaDeathInvite {
 
 impl PermaDeathInvite {
     pub fn rsvp(self, actor_name: String, exit_status: ExitStatus) {
+        // TODO: consider asserting death by recieving the target actor's
+        // `Context` and using `stop`
         // FIXME: `do_send` might fail if actor "mailbox" is full
         self.reaper_addr.do_send(InviteAccepted {
             actor_name,
@@ -81,4 +86,3 @@ impl Handler<InviteAccepted> for GrimReaperActor {
         }
     }
 }
-

--- a/src/actors/mod.rs
+++ b/src/actors/mod.rs
@@ -1,3 +1,4 @@
 pub mod command;
 pub mod console;
+pub mod grim_reaper;
 pub mod watcher;

--- a/src/args.rs
+++ b/src/args.rs
@@ -47,7 +47,7 @@ pub struct Args {
     #[clap(long)]
     pub list_jobs: bool,
 
-    /// Whiz will exit after all commands have finished executing.
+    /// Whiz will exit after all tasks have finished executing.
     #[clap(long)]
     pub exit_after: bool,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -46,4 +46,12 @@ pub struct Args {
     /// List all the jobs set in the config file
     #[clap(long)]
     pub list_jobs: bool,
+
+    /// Whiz will exit after all commands have finished executing.
+    #[clap(long)]
+    pub exit_after: bool,
+
+    /// Disables triggering task reloading from any watched files
+    #[clap(long)]
+    pub no_watch: bool,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -36,6 +36,7 @@ pub struct Args {
     #[clap(short, long)]
     pub verbose: bool,
 
+    /// Enable timestamps in logging
     #[clap(short, long)]
     pub timestamp: bool,
 
@@ -48,10 +49,11 @@ pub struct Args {
     pub list_jobs: bool,
 
     /// Whiz will exit after all tasks have finished executing.
+    /// This disables fs watching despite any values given to the `watch` flag.
     #[clap(long)]
     pub exit_after: bool,
 
-    /// Disables triggering task reloading from any watched files
-    #[clap(long)]
-    pub no_watch: bool,
+    /// Globally toggle triggering task reloading from any watched files
+    #[clap(long, default_value = "true", value_name = "WATCH")]
+    pub watch: Option<bool>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,17 +159,23 @@ async fn run(args: Args) -> Result<()> {
     let console =
         ConsoleActor::new(Vec::from_iter(config.ops.keys().cloned()), args.timestamp).start();
     let watcher = WatcherActor::new(base_dir.clone()).start();
-    let cmds = CommandActorsBuilder::new(config, console.clone(), watcher, base_dir.clone(), colors_map)
-        .verbose(args.verbose)
-        .pipes_map(pipes_map)
-        .globally_enable_watch(if args.exit_after {
-            false
-        } else {
-            args.watch.unwrap_or(true)
-        })
-        .build()
-        .await
-        .map_err(|err| anyhow!("error spawning commands: {}", err))?;
+    let cmds = CommandActorsBuilder::new(
+        config,
+        console.clone(),
+        watcher,
+        base_dir.clone(),
+        colors_map,
+    )
+    .verbose(args.verbose)
+    .pipes_map(pipes_map)
+    .globally_enable_watch(if args.exit_after {
+        false
+    } else {
+        args.watch.unwrap_or(true)
+    })
+    .build()
+    .await
+    .map_err(|err| anyhow!("error spawning commands: {}", err))?;
 
     if args.exit_after {
         whiz::actors::grim_reaper::GrimReaperActor::start_new(cmds).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,9 @@ use clap::Parser;
 use self_update::{backends::github::Update, cargo_crate_version, update::UpdateStatus};
 use semver::Version;
 use tokio::time::{sleep, Duration as TokioDuration};
+use whiz::actors::command::CommandActorsBuilder;
 use whiz::{
-    actors::{command::CommandActor, console::ConsoleActor, watcher::WatcherActor},
+    actors::{console::ConsoleActor, watcher::WatcherActor},
     args::Command,
     config::Config,
     global_config::GlobalConfig,
@@ -111,9 +112,8 @@ fn main() -> Result<()> {
         })
     });
 
-    let _ = system.run();
-
-    Ok(())
+    let code = system.run_with_code()?;
+    std::process::exit(code);
 }
 
 async fn run(args: Args) -> Result<()> {
@@ -159,18 +159,17 @@ async fn run(args: Args) -> Result<()> {
     let console =
         ConsoleActor::new(Vec::from_iter(config.ops.keys().cloned()), args.timestamp).start();
     let watcher = WatcherActor::new(base_dir.clone()).start();
-    let cmds = CommandActor::from_config(
-        &config,
-        console.clone(),
-        watcher,
-        base_dir.clone(),
-        args.verbose,
-        pipes_map,
-        colors_map,
-        args.no_watch,
-    )
-    .await
-    .map_err(|err| anyhow!("error spawning commands: {}", err))?;
+    let cmds = CommandActorsBuilder::new(config, console.clone(), watcher, base_dir.clone(), colors_map)
+        .verbose(args.verbose)
+        .pipes_map(pipes_map)
+        .globally_enable_watch(if args.exit_after {
+            false
+        } else {
+            args.watch.unwrap_or(true)
+        })
+        .build()
+        .await
+        .map_err(|err| anyhow!("error spawning commands: {}", err))?;
 
     if args.exit_after {
         whiz::actors::grim_reaper::GrimReaperActor::start_new(cmds).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,7 @@ async fn run(args: Args) -> Result<()> {
         args.verbose,
         pipes_map,
         colors_map,
+        args.no_watch,
     )
     .await
     .map_err(|err| anyhow!("error spawning commands: {}", err))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,7 +159,7 @@ async fn run(args: Args) -> Result<()> {
     let console =
         ConsoleActor::new(Vec::from_iter(config.ops.keys().cloned()), args.timestamp).start();
     let watcher = WatcherActor::new(base_dir.clone()).start();
-    CommandActor::from_config(
+    let cmds = CommandActor::from_config(
         &config,
         console.clone(),
         watcher,
@@ -171,6 +171,10 @@ async fn run(args: Args) -> Result<()> {
     )
     .await
     .map_err(|err| anyhow!("error spawning commands: {}", err))?;
+
+    if args.exit_after {
+        whiz::actors::grim_reaper::GrimReaperActor::start_new(cmds).await?;
+    }
 
     Ok(())
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -118,35 +118,15 @@ fn test_grim_reaper() {
     });
 
     let fut = async move {
-        let config_raw = {
-            #[cfg(not(target_os = "windows"))]
-            {
-                r#"
+        let config_raw =r#"
 test:
-    command: ls
+    command: python3 -c 'print("hello whiz")'
 long_test_dep:
-    command: sleep 1; echo "wake up";
+    command: python3 -c 'import time; time.sleep(1); print("wake up")'
 long_test:
-    command: echo "my que to enter"
+    command: python3 -c 'print("my que to enter")'
     depends_on:
-        - long_test_dep
-            "#
-            }
-
-            #[cfg(target_os = "windows")]
-            {
-                r#"
-test:
-    command: dir
-long_test_dep:
-    command: PING 1.1.1.2 -n 1 -w 1000 >NUL && echo "wake up"
-long_test:
-    command: echo "my que to enter"
-    depends_on:
-        - long_test_dep
-            "#
-            }
-        };
+        - long_test_dep"#;
         let config: Config = config_raw.parse()?;
 
         let console = mock_actor!(ConsoleActor, {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -122,7 +122,7 @@ fn test_grim_reaper() {
             test:
                 command: ls
             long_test_dep:
-                command: sleep 1s; echo "wake up";
+                command: sleep 1; echo "wake up";
             long_test:
                 command: echo "my que to enter"
                 depends_on:
@@ -158,7 +158,10 @@ fn test_grim_reaper() {
     let timer = std::time::SystemTime::now();
     assert_eq!(0, system.run_with_code().unwrap());
     let elapsed = timer.elapsed().unwrap();
-    assert!(elapsed.as_secs_f64() > 1.0);
+    assert!(
+        elapsed.as_millis() >= 1000,
+        "test took less than a second: {elapsed:?}"
+    );
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -130,8 +130,12 @@ fn test_grim_reaper() {
         let config: Config = r#"
             test:
                 command: ls
-            longtest:
+            long_test_dep:
                 command: sleep 1s; echo "wake up";
+            long_test:
+                command: echo "my que to enter"
+                depends_on:
+                    - long_test_dep
             "#
         .parse()?;
 
@@ -170,7 +174,6 @@ fn test_grim_reaper() {
     assert_eq!(0, system.run_with_code().unwrap());
     let elapsed = timer.elapsed().unwrap();
     assert!(elapsed.as_secs_f64() > 1.0);
-    assert!(elapsed.as_secs_f64() < 2.0);
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -139,7 +139,7 @@ long_test:
 test:
     command: dir
 long_test_dep:
-    command: TIMEOUT /T 1 && echo "wake up"
+    command: PING 1.1.1.2 -n 1 -w 1000 >NUL && echo "wake up"
 long_test:
     command: echo "my que to enter"
     depends_on:

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -120,11 +120,14 @@ fn test_grim_reaper() {
     let fut = async move {
         let config_raw =r#"
 test:
-    command: python3 -c 'print("hello whiz")'
+    entrypoint: 'python3 -c'
+    command: 'print("hello whiz")'
 long_test_dep:
-    command: python3 -c 'import time; time.sleep(1); print("wake up")'
+    entrypoint: 'python3 -c'
+    command: 'import time; time.sleep(1); print("wake up")'
 long_test:
-    command: python3 -c 'print("my que to enter")'
+    entrypoint: 'python3 -c'
+    command: 'print("my que to enter")'
     depends_on:
         - long_test_dep"#;
         let config: Config = config_raw.parse()?;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::Path;
 use std::{env, future::Future};
 
@@ -6,13 +5,12 @@ use anyhow::{Ok, Result};
 
 use subprocess::ExitStatus;
 
-use crate::actors::command::WaitStatus;
+use crate::actors::command::{CommandActorsBuilder, WaitStatus};
 use crate::actors::console::RegisterPanel;
 use crate::actors::watcher::WatchGlob;
 use crate::args::Args;
 use crate::{
     actors::{
-        command::CommandActor,
         console::{ConsoleActor, Output, PanelStatus, TermEvent},
         grim_reaper::GrimReaperActor,
         watcher::WatcherActor,
@@ -92,17 +90,10 @@ fn hello() {
             ))
             .await?;
 
-        let commands = CommandActor::from_config(
-            &config,
-            console,
-            watcher,
-            env::current_dir().unwrap(),
-            false,
-            HashMap::new(),
-            HashMap::new(),
-            false,
-        )
-        .await?;
+        let commands =
+            CommandActorsBuilder::new(config, console, watcher, env::current_dir().unwrap(), HashMap::new())
+                .build()
+                .await?;
 
         let status = commands
             .get(&"test".to_string())
@@ -153,16 +144,10 @@ fn test_grim_reaper() {
             _msg: WatchGlob => Some(()),
         });
 
-        let commands = CommandActor::from_config(
-            &config,
-            console,
-            watcher,
-            env::current_dir().unwrap(),
-            false,
-            HashMap::new(),
-            false,
-        )
-        .await?;
+        let commands =
+            CommandActorsBuilder::new(config, console, watcher, env::current_dir().unwrap())
+                .build()
+                .await?;
 
         GrimReaperActor::start_new(commands).await?;
         Ok(())

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -90,10 +90,15 @@ fn hello() {
             ))
             .await?;
 
-        let commands =
-            CommandActorsBuilder::new(config, console, watcher, env::current_dir().unwrap(), HashMap::new())
-                .build()
-                .await?;
+        let commands = CommandActorsBuilder::new(
+            config,
+            console,
+            watcher,
+            env::current_dir().unwrap(),
+            Default::default(),
+        )
+        .build()
+        .await?;
 
         let status = commands
             .get(&"test".to_string())
@@ -118,7 +123,7 @@ fn test_grim_reaper() {
     });
 
     let fut = async move {
-        let config_raw =r#"
+        let config_raw = r#"
 test:
     entrypoint: 'python3 -c'
     command: 'print("hello whiz")'
@@ -146,10 +151,15 @@ long_test:
             _msg: WatchGlob => Some(()),
         });
 
-        let commands =
-            CommandActorsBuilder::new(config, console, watcher, env::current_dir().unwrap())
-                .build()
-                .await?;
+        let commands = CommandActorsBuilder::new(
+            config,
+            console,
+            watcher,
+            env::current_dir().unwrap(),
+            Default::default(),
+        )
+        .build()
+        .await?;
 
         GrimReaperActor::start_new(commands).await?;
         Ok(())


### PR DESCRIPTION
This PR fixes #83. 

I've decided to go with a straight forward solution that, when the program is provided with the `--exit-after` flag, uses an `Actor` that asks the `CommandActor`s to tell it when they're finished. Once it has the go from all its targets, it exits the program. 

In order to make the tool more CI friendly, I've also introduced a `--no-watch` flag that globally disables reloading triggered by fs watch events. I also recommend adding, in this PR or another, code that disables the `Console` actor when not needed and joins all the child std pipes. The console makes little sense in a CI context.