### PR TITLE
fix: add short flag/option for version flag

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -36,7 +36,7 @@ pub enum Command {
     long_about= None,
 )]
 pub struct Args {
-    #[arg(long)]
+    #[arg(short = 'V', long)]
     pub version: bool,
 
     #[command(subcommand)]


### PR DESCRIPTION
the short option of the version flag(--version) was throwing "unrecognized subcommand 'V'" error, fix to add the short flag. 