### PR TITLE
fix: ui white flash at start up

### DIFF
--- a/src/actors/console.rs
+++ b/src/actors/console.rs
@@ -188,7 +188,7 @@ impl ConsoleActor {
         self.terminal
             .draw(|f| {
                 let clean =
-                    Block::default().style(Style::default().bg(Color::White).fg(Color::Black));
+                    Block::default().style(Style::default().fg(Color::Black));
                 f.render_widget(clean, f.size());
             })
             .unwrap();


### PR DESCRIPTION
It seems removing the background color fixes the bug metioned in [#114](https://github.com/zifeo/whiz/issues/114)